### PR TITLE
Support macOS ARM and python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
         cache: 'pip'
     - name: Download redis
       run: |
-        wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.focal.x86_64.tar.gz
-        tar -xvzf redis-stack-server-7.2.0-v9.focal.x86_64.tar.gz
-        rm redis-stack-server-7.2.0-v9.focal.x86_64.tar.gz
+        wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.focal.x86_64.tar.gz -O redis-stack.tar.gz
+        tar -xvzf redis-stack.tar.gz
+        rm redis-stack.tar.gz
         mv redis-stack-server-7.2.0-v9 src/redis_stack_wheel/redis-stack-server
     - name: Overwrite server startup file
       run: cp overwrite/redis-stack-server src/redis_stack_wheel/redis-stack-server/bin/redis-stack-server
@@ -102,9 +102,9 @@ jobs:
       
     - name: Download redis
       run: |
-        wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.catalina.x86_64.zip
-        unzip -d redis-stack-server redis-stack-server-7.2.0-v9.catalina.x86_64.zip
-        rm redis-stack-server-7.2.0-v9.catalina.x86_64.zip
+        wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.catalina.x86_64.zip -O redis-stack.zip
+        unzip -d redis-stack.zip
+        rm redis-stack.zip
         mv redis-stack-server src/redis_stack_wheel/redis-stack-server
     - name: Overwrite server startup file
       run: cp overwrite/redis-stack-server src/redis_stack_wheel/redis-stack-server/bin/redis-stack-server
@@ -125,4 +125,63 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: distribution-macos-x64-${{ matrix.python_version }}
+        path: dist/
+
+ build-macos-arm:
+  needs: checkout
+  runs-on: macOS-14
+  strategy:
+    matrix:
+      our_version:
+        - "0.1.4"
+      python_version:
+        - "3.9"
+      include:
+        - python_version: "3.9"
+          abi_tag: "cp39-cp39"
+  steps:
+    - name: Download checkout
+      uses: actions/download-artifact@v4
+      with:
+        name: checkout
+        path: .
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python_version }}
+        cache: 'pip'
+
+    - name: List available Xcode versions
+      run: ls /Applications | grep Xcode
+
+    - name: Set up Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer      
+
+    - name: Show current version of Xcode
+      run: xcodebuild -version
+      
+    - name: Download redis
+      run: |
+        wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.monterey.arm64.zip -O redis-stack.zip
+        unzip -d redis-stack.zip
+        rm redis-stack.zip
+        mv redis-stack-server src/redis_stack_wheel/redis-stack-server
+    - name: Overwrite server startup file
+      run: cp overwrite/redis-stack-server src/redis_stack_wheel/redis-stack-server/bin/redis-stack-server
+    - run: python -m pip install build
+    - name: Build
+      run: python -m build --wheel
+    - name: List dir for sanity checking
+      run: ls -R
+
+    - name: Rename wheel
+      run: |
+        BUILD_TAG=$(date -u "+%Y%m%d%H%M")
+        WHL_NAME="dist/redis_stack_wheel-${{ matrix.our_version }}-${BUILD_TAG}-${{ matrix.abi_tag }}-macosx_14_0_arm.whl"
+        mv dist/redis_stack_wheel-${{ matrix.our_version }}-py3-none-any.whl $WHL_NAME
+        echo $WHL_NAME
+
+    - name: Upload distribution
+      uses: actions/upload-artifact@v4
+      with:
+        name: distribution-macos-arm-${{ matrix.python_version }}
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
 
  build-macos-x64:
   needs: checkout
+  # macOS-13 is Intel runner!
   runs-on: macOS-13
   strategy:
     matrix:
@@ -132,6 +133,7 @@ jobs:
 
  build-macos-arm:
   needs: checkout
+  # macOS-13 is ARM runner!
   runs-on: macOS-14
   strategy:
     matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Download redis
       run: |
         wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.catalina.x86_64.zip -O redis-stack.zip
-        unzip -d redis-stack.zip
+        unzip -d redis-stack-server redis-stack.zip
         rm redis-stack.zip
         mv redis-stack-server src/redis_stack_wheel/redis-stack-server
     - name: Overwrite server startup file
@@ -162,7 +162,7 @@ jobs:
     - name: Download redis
       run: |
         wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.monterey.arm64.zip -O redis-stack.zip
-        unzip -d redis-stack.zip
+        unzip -d redis-stack-server redis-stack.zip
         rm redis-stack.zip
         mv redis-stack-server src/redis_stack_wheel/redis-stack-server
     - name: Overwrite server startup file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
  push:
   branches:
     - main
-    - paulan/new_builds
+
  workflow_call:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,12 @@ jobs:
         - "0.1.4"
       python_version:
         - "3.9"
+        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
+        - python_version: "3.11"
+          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
       uses: actions/download-artifact@v4
@@ -77,12 +80,9 @@ jobs:
         - "0.1.4"
       python_version:
         - "3.9"
-        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
-        - python_version: "3.11"
-          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
       uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,12 @@ jobs:
         - "0.1.4"
       python_version:
         - "3.9"
+        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
+        - python_version: "3.11"
+          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
       uses: actions/download-artifact@v4
@@ -136,9 +139,12 @@ jobs:
         - "0.1.4"
       python_version:
         - "3.9"
+        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
+        - python_version: "3.11"
+          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
       uses: actions/download-artifact@v4
@@ -176,7 +182,7 @@ jobs:
     - name: Rename wheel
       run: |
         BUILD_TAG=$(date -u "+%Y%m%d%H%M")
-        WHL_NAME="dist/redis_stack_wheel-${{ matrix.our_version }}-${BUILD_TAG}-${{ matrix.abi_tag }}-macosx_14_0_arm.whl"
+        WHL_NAME="dist/redis_stack_wheel-${{ matrix.our_version }}-${BUILD_TAG}-${{ matrix.abi_tag }}-macosx_14_0_arm64.whl"
         mv dist/redis_stack_wheel-${{ matrix.our_version }}-py3-none-any.whl $WHL_NAME
         echo $WHL_NAME
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
  push:
   branches:
     - main
+    - paulan/new_builds
  workflow_call:
 
 jobs:
@@ -64,10 +65,10 @@ jobs:
     - name: Upload distribution
       uses: actions/upload-artifact@v4
       with:
-        name: distribution-linux
+        name: distribution-linux-${{ matrix.python_version }}
         path: dist/
 
- build-macos:
+ build-macos-x64:
   needs: checkout
   runs-on: macOS-11
   strategy:
@@ -113,5 +114,5 @@ jobs:
     - name: Upload distribution
       uses: actions/upload-artifact@v4
       with:
-        name: distribution-macos
+        name: distribution-macos-x64-${{ matrix.python_version }}
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
 
  build-macos-x64:
   needs: checkout
-  runs-on: macOS-11
+  runs-on: macOS-13
   strategy:
     matrix:
       our_version:
@@ -90,6 +90,16 @@ jobs:
       with:
         python-version: ${{ matrix.python_version }}
         cache: 'pip'
+
+    - name: List available Xcode versions
+      run: ls /Applications | grep Xcode
+
+    - name: Set up Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer      
+
+    - name: Show current version of Xcode
+      run: xcodebuild -version
+      
     - name: Download redis
       run: |
         wget https://packages.redis.io/redis-stack/redis-stack-server-7.2.0-v9.catalina.x86_64.zip
@@ -107,7 +117,7 @@ jobs:
     - name: Rename wheel
       run: |
         BUILD_TAG=$(date -u "+%Y%m%d%H%M")
-        WHL_NAME="dist/redis_stack_wheel-${{ matrix.our_version }}-${BUILD_TAG}-${{ matrix.abi_tag }}-macosx_11_0_x86_64.whl"
+        WHL_NAME="dist/redis_stack_wheel-${{ matrix.our_version }}-${BUILD_TAG}-${{ matrix.abi_tag }}-macosx_14_0_x86_64.whl"
         mv dist/redis_stack_wheel-${{ matrix.our_version }}-py3-none-any.whl $WHL_NAME
         echo $WHL_NAME
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
 
  build-macos-arm:
   needs: checkout
-  # macOS-13 is ARM runner!
+  # macOS-14 is ARM runner!
   runs-on: macOS-14
   strategy:
     matrix:

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Supported versions of Redis Stack:
 
 Supported platforms:
 
-- `manylinux2014_x86_64`
-- `macosx_11_0_x86_64`
+- `manylinux_2_31_x86_64`
+- `macosx_14_0_x86_64`
+- `macosx_14_0_arm64`
 
 Supported python versions:
 
 - `cp39`
+- `cp311` (except mac x64)
 
 To get the paths of pre-compiled Redis binaries:
 


### PR DESCRIPTION
Update runners and actions to support versions since last update

macOS-13 for Intel
macOS-14 for ARM
Set xcode version to 14.3.1 so that we don't target only newer macOS versions.