### PR TITLE
Attempt to unbreak the pypi publish action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # set PACKAGE_VERSION in a central place, needs to match pyproject.toml
-  PACKAGE_VERSION: "0.1.6"
+  PACKAGE_VERSION: "0.1.7"
   REDIS_VERSION: "7.4.0-v1"
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
     - name: List artifacts downloaded
       run: ls -R dist
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.8
+      uses: pypa/gh-action-pypi-publish@release/v1.12.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redis-stack-wheel"
-version = "0.1.6"
+version = "0.1.7"
 description = "Wheels that bundle precompiled redis-stack-server binaries for the appropriate platform. Currently on Redis Stack v7.4.0-v1"
 license = {file = "LICENSE"}
 authors = [

--- a/src/redis_stack_wheel/__init__.py
+++ b/src/redis_stack_wheel/__init__.py
@@ -1,3 +1,4 @@
+
 from os.path import dirname, join
 
 __all__ = ['REDIS_SERVER_PATH', 'REDIS_CLI_PATH']


### PR DESCRIPTION
I think PyPi is rejecting the Linux Python39 bundle because it hashes to the same thing as a previous release.  Let's try making a change that should make the hash different.